### PR TITLE
Creación de pruebas unitarias.

### DIFF
--- a/PruebaGregor.sln
+++ b/PruebaGregor.sln
@@ -13,13 +13,15 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Infrastructure", "Infrastru
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Test", "Test", "{74BF71AF-BB68-4A03-ACE8-4CA0E255051D}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Infrastructure", "Infrastructure\Infrastructure.csproj", "{C68926D7-D013-4F84-B065-7F70D7937FDA}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Infrastructure", "Infrastructure\Infrastructure.csproj", "{C68926D7-D013-4F84-B065-7F70D7937FDA}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Application", "Application\Application.csproj", "{F34B881F-067F-4500-B8D1-8D59EFC9F923}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Application", "Application\Application.csproj", "{F34B881F-067F-4500-B8D1-8D59EFC9F923}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Models", "Models\Models.csproj", "{60513B6D-D0AE-4CB3-B91D-B3E4B3BDDC05}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Models", "Models\Models.csproj", "{60513B6D-D0AE-4CB3-B91D-B3E4B3BDDC05}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebApi", "WebApi\WebApi.csproj", "{58B6FB26-A58B-4698-91CE-C083E51A898D}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WebApi", "WebApi\WebApi.csproj", "{58B6FB26-A58B-4698-91CE-C083E51A898D}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UnitTest", "UnitTest\UnitTest.csproj", "{743859CA-93E1-4D75-93A1-3ED993A7100D}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -43,6 +45,10 @@ Global
 		{58B6FB26-A58B-4698-91CE-C083E51A898D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{58B6FB26-A58B-4698-91CE-C083E51A898D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{58B6FB26-A58B-4698-91CE-C083E51A898D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{743859CA-93E1-4D75-93A1-3ED993A7100D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{743859CA-93E1-4D75-93A1-3ED993A7100D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{743859CA-93E1-4D75-93A1-3ED993A7100D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{743859CA-93E1-4D75-93A1-3ED993A7100D}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -56,6 +62,7 @@ Global
 		{F34B881F-067F-4500-B8D1-8D59EFC9F923} = {595EC749-AFA9-44F0-99AE-DE359E3E8ED0}
 		{60513B6D-D0AE-4CB3-B91D-B3E4B3BDDC05} = {595EC749-AFA9-44F0-99AE-DE359E3E8ED0}
 		{58B6FB26-A58B-4698-91CE-C083E51A898D} = {0CB7CC02-A677-436E-A7AD-7ECB70B64AA4}
+		{743859CA-93E1-4D75-93A1-3ED993A7100D} = {74BF71AF-BB68-4A03-ACE8-4CA0E255051D}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {7B7CA3C2-B6E3-4A18-9D3E-14A359D89954}

--- a/UnitTest/Features/Accion/Commands/CreateAccion/CreateAccionCommandHandlerXUnitTests.cs
+++ b/UnitTest/Features/Accion/Commands/CreateAccion/CreateAccionCommandHandlerXUnitTests.cs
@@ -1,0 +1,52 @@
+﻿using Application.Features.Accion.Commands.CreateAccion;
+using Application.Mappings;
+using AutoMapper;
+using Infrastructure.Repositories;
+using Microsoft.AspNetCore.Http;
+using Models.Models;
+using Models.Utils;
+using Moq;
+using Shouldly;
+using UnitTest.Mocks;
+using Xunit;
+
+namespace UnitTest.Features.Accion.Commands.CreateAccion
+{
+    public class CreateAccionCommandHandlerXUnitTests
+    {
+        private readonly IMapper _mapper;
+        private readonly Mock<UnitOfWork> _unitOfWork;
+
+        public CreateAccionCommandHandlerXUnitTests()
+        {
+            _unitOfWork = MockUnitOfWork.GetUnitOfWork();
+
+            var mapperConfig = new MapperConfiguration(c =>
+            {
+                c.AddProfile<AccionProfile>();
+            });
+
+            _mapper = mapperConfig.CreateMapper();
+
+            MockAccionRepository.AddDataAccion(_unitOfWork.Object.pruebaTecnicaContext);
+        }
+        [Fact]
+        public async Task CrearAccion_Return()
+        {
+            var CreateAccionInput = new CreateAccionCommand
+            {
+                DescripcionAccion = "Pepito",
+                Estado = false,
+                Eliminar = false
+            };
+
+            var CreateAccionOutput = new CreateAccionCommandsHandler(_unitOfWork.Object, _mapper);
+
+            var CUresult = await CreateAccionOutput.Handle(CreateAccionInput, CancellationToken.None);
+
+            CUresult.ShouldBeOfType<ApiResponse<string>>();
+
+            Assert.True(CUresult.CodeResult == StatusCodes.Status200OK.ToString());
+        }
+    }
+}

--- a/UnitTest/Features/Accion/Commands/UpdateAccion/UpdateAccionCommandHandlerXUnitTests.cs
+++ b/UnitTest/Features/Accion/Commands/UpdateAccion/UpdateAccionCommandHandlerXUnitTests.cs
@@ -1,0 +1,54 @@
+﻿using Application.Features.Accion.Commands.CreateAccion;
+using Application.Features.Accion.Commands.UpdateAccion;
+using Application.Mappings;
+using AutoMapper;
+using Infrastructure.Repositories;
+using Microsoft.AspNetCore.Http;
+using Models.Utils;
+using Moq;
+using Shouldly;
+using UnitTest.Mocks;
+using Xunit;
+
+namespace UnitTest.Features.Accion.Commands.UpdateAccion
+{
+    public class UpdateAccionCommandHandlerXUnitTests
+    {
+        private readonly IMapper _mapper;
+        private readonly Mock<UnitOfWork> _unitOfWork;
+
+        public UpdateAccionCommandHandlerXUnitTests()
+        {
+            _unitOfWork = MockUnitOfWork.GetUnitOfWork();
+
+            var mapperConfig = new MapperConfiguration(c =>
+            {
+                c.AddProfile<AccionProfile>();
+            });
+
+            _mapper = mapperConfig.CreateMapper();
+
+            MockAccionRepository.AddDataAccion(_unitOfWork.Object.pruebaTecnicaContext);
+        }
+        [Fact]
+        public async Task UpdateAccion_Return()
+        {
+            var UpdateAccionInput = new UpdateAccionCommand
+            {
+                Id = "Ide513cdc3-7bfd-4604-8eb7-fc4715b14d96",
+                DescripcionAccion = "Test",
+                Estado = false,
+                Eliminar = false
+            };
+
+            var UpdateAccionOutput = new UpdateAccionCommandHandler(_unitOfWork.Object, _mapper);
+
+            var result = await UpdateAccionOutput.Handle(UpdateAccionInput, CancellationToken.None);
+
+            result.ShouldBeOfType<ApiResponse<bool>>();
+
+            Assert.True(result.CodeResult == StatusCodes.Status404NotFound.ToString());
+        }
+    }
+}
+

--- a/UnitTest/Features/Accion/Commands/UpdateEliminarAccion/UpdateEliminarAccionCommandHandlerXUnitTests.cs
+++ b/UnitTest/Features/Accion/Commands/UpdateEliminarAccion/UpdateEliminarAccionCommandHandlerXUnitTests.cs
@@ -1,0 +1,42 @@
+﻿using Application.Features.Accion.Commands.UpdateAccion;
+using Application.Features.Accion.Commands.UpdateEliminarAccion;
+using Application.Mappings;
+using AutoMapper;
+using Infrastructure.Repositories;
+using Microsoft.AspNetCore.Http;
+using Models.Utils;
+using Moq;
+using Shouldly;
+using UnitTest.Mocks;
+using Xunit;
+
+namespace UnitTest.Features.Accion.Commands.UpdateEliminarAccion
+{
+    public class UpdateEliminarAccionCommandHandlerXUnitTests
+    {
+        private readonly Mock<UnitOfWork> _unitOfWork;
+
+        public UpdateEliminarAccionCommandHandlerXUnitTests()
+        {
+            _unitOfWork = MockUnitOfWork.GetUnitOfWork();
+
+            MockAccionRepository.AddDataAccion(_unitOfWork.Object.pruebaTecnicaContext);
+        }
+        [Fact]
+        public async Task UpdateAccionStatusEliminar_Return()
+        {
+            var UpdateAccionInput = new UpdateEliminarAccionCommand
+            {
+                Id = "Ide513cdc3-7bfd-4604-8eb7-fc4715b14d96",
+            };
+
+            var UpdateAccionOutput = new UpdateEliminarAccionCommandHandler(_unitOfWork.Object);
+
+            var result = await UpdateAccionOutput.Handle(UpdateAccionInput, CancellationToken.None);
+
+            result.ShouldBeOfType<ApiResponse<bool>>();
+
+            Assert.True(result.CodeResult == StatusCodes.Status404NotFound.ToString());
+        }
+    }
+}

--- a/UnitTest/Features/Accion/Commands/UpdateStatusAccion/UpdateStatusAccionCommandHandlerXUnitTests.cs
+++ b/UnitTest/Features/Accion/Commands/UpdateStatusAccion/UpdateStatusAccionCommandHandlerXUnitTests.cs
@@ -1,0 +1,45 @@
+﻿using Application.Features.Accion.Commands.UpdateEliminarAccion;
+using Application.Features.Accion.Commands.UpdateStatusAccion;
+using Infrastructure.Repositories;
+using Microsoft.AspNetCore.Http;
+using Models.Utils;
+using Moq;
+using Shouldly;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using UnitTest.Mocks;
+using Xunit;
+
+namespace UnitTest.Features.Accion.Commands.UpdateStatusAccion
+{
+    public class UpdateStatusAccionCommandHandlerXUnitTests
+    {
+        private readonly Mock<UnitOfWork> _unitOfWork;
+
+        public UpdateStatusAccionCommandHandlerXUnitTests()
+        {
+            _unitOfWork = MockUnitOfWork.GetUnitOfWork();
+
+            MockAccionRepository.AddDataAccion(_unitOfWork.Object.pruebaTecnicaContext);
+        }
+        [Fact]
+        public async Task UpdateAccionStatus_Return()
+        {
+            var UpdateAccionInput = new UpdateStatusAccionCommand
+            {
+                Id = "Ide513cdc3-7bfd-4604-8eb7-fc4715b14d96",
+            };
+
+            var UpdateAccionOutput = new UpdateStatusAccionCommandHandler(_unitOfWork.Object);
+
+            var result = await UpdateAccionOutput.Handle(UpdateAccionInput, CancellationToken.None);
+
+            result.ShouldBeOfType<ApiResponse<bool>>();
+
+            Assert.True(result.CodeResult == StatusCodes.Status404NotFound.ToString());
+        }
+    }
+}

--- a/UnitTest/Features/Accion/Queries/GetAllAccionListHandlerXUnitTests.cs
+++ b/UnitTest/Features/Accion/Queries/GetAllAccionListHandlerXUnitTests.cs
@@ -1,0 +1,53 @@
+﻿using Application.Features.Accion.Queries;
+using Application.Mappings;
+using AutoMapper;
+using Infrastructure.Repositories;
+using Microsoft.AspNetCore.Http;
+using Models.Models;
+using Models.Utils;
+using Moq;
+using Shouldly;
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using UnitTest.Mocks;
+using Xunit;
+
+namespace UnitTest.Features.Accion.Queries
+{
+    public class GetAllAccionListHandlerXUnitTests
+    {
+        private readonly IMapper _mapper;
+        private readonly Mock<UnitOfWork> _unitOfWork;
+
+        public GetAllAccionListHandlerXUnitTests()
+        {
+            _unitOfWork = MockUnitOfWork.GetUnitOfWork();
+            var mapperConfig = new MapperConfiguration(c =>
+            {
+                c.AddProfile<AccionProfile>();
+            });
+            _mapper = mapperConfig.CreateMapper();
+
+            MockAccionRepository.AddDataAccion(_unitOfWork.Object.pruebaTecnicaContext);
+        }
+
+        [Fact]
+        public async Task GetAllAccionList_Return()
+        {
+            var handler = new GetAllAccionHandler(_unitOfWork.Object);
+
+            var request = new GetAllAccion();
+
+            var result = await handler.Handle(request, CancellationToken.None);
+
+            result.ShouldBeOfType<ApiResponse<List<AccionTexto>>>();
+
+            Assert.True(result.CodeResult == StatusCodes.Status200OK.ToString());
+        }
+    }
+}
+

--- a/UnitTest/Features/Accion/Queries/GetByDescripcionAccionHandlerXUnitTests.cs
+++ b/UnitTest/Features/Accion/Queries/GetByDescripcionAccionHandlerXUnitTests.cs
@@ -1,0 +1,49 @@
+﻿using Application.Features.Accion.Queries;
+using Application.Mappings;
+using AutoMapper;
+using Infrastructure.Repositories;
+using Microsoft.AspNetCore.Http;
+using Models.Utils;
+using Moq;
+using Shouldly;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using UnitTest.Mocks;
+using Xunit;
+
+namespace UnitTest.Features.Accion.Queries
+{
+    public class GetByDescripcionAccionHandlerXUnitTests
+    {
+        private readonly IMapper _mapper;
+        private readonly Mock<UnitOfWork> _unitOfWork;
+
+        public GetByDescripcionAccionHandlerXUnitTests()
+        {
+            _unitOfWork = MockUnitOfWork.GetUnitOfWork();
+            var mapperConfig = new MapperConfiguration(c =>
+            {
+                c.AddProfile<AccionProfile>();
+            });
+            _mapper = mapperConfig.CreateMapper();
+
+            MockAccionRepository.AddDataAccion(_unitOfWork.Object.pruebaTecnicaContext);
+        }
+        [Fact]
+        public async Task GetByDescripcionAccion_Return()
+        {
+            var handler = new GetByDescripcionAccionHandler(_unitOfWork.Object);
+
+            var request = new GetByDescripcionAccion("D");
+
+            var result = await handler.Handle(request, CancellationToken.None);
+
+            result.ShouldBeOfType<ApiResponse<List<AccionTexto>>>();
+
+            Assert.True(result.CodeResult == StatusCodes.Status200OK.ToString());
+        }
+    }
+}

--- a/UnitTest/Features/Accion/Queries/GetByStatusHandlerXUnitTests.cs
+++ b/UnitTest/Features/Accion/Queries/GetByStatusHandlerXUnitTests.cs
@@ -1,0 +1,49 @@
+﻿using Application.Features.Accion.Queries;
+using Application.Mappings;
+using AutoMapper;
+using Infrastructure.Repositories;
+using Microsoft.AspNetCore.Http;
+using Models.Utils;
+using Moq;
+using Shouldly;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using UnitTest.Mocks;
+using Xunit;
+
+namespace UnitTest.Features.Accion.Queries
+{
+    public class GetByStatusHandlerXUnitTests
+    {
+        private readonly IMapper _mapper;
+        private readonly Mock<UnitOfWork> _unitOfWork;
+
+        public GetByStatusHandlerXUnitTests()
+        {
+            _unitOfWork = MockUnitOfWork.GetUnitOfWork();
+            var mapperConfig = new MapperConfiguration(c =>
+            {
+                c.AddProfile<AccionProfile>();
+            });
+            _mapper = mapperConfig.CreateMapper();
+
+            MockAccionRepository.AddDataAccion(_unitOfWork.Object.pruebaTecnicaContext);
+        }
+        [Fact]
+        public async Task GetByDescripcionAccion_Return()
+        {
+            var handler = new GetByStatusHandler(_unitOfWork.Object);
+
+            var request = new GetByStatus(true);
+
+            var result = await handler.Handle(request, CancellationToken.None);
+
+            result.ShouldBeOfType<ApiResponse<List<AccionTexto>>>();
+
+            Assert.True(result.CodeResult == StatusCodes.Status200OK.ToString());
+        }
+    }
+}

--- a/UnitTest/Mocks/MockAccionRepository.cs
+++ b/UnitTest/Mocks/MockAccionRepository.cs
@@ -1,0 +1,31 @@
+﻿using AutoFixture;
+using Infrastructure.Persistence;
+using Models.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace UnitTest.Mocks
+{
+    public class MockAccionRepository
+    {
+        public static void AddDataAccion(ApplicationDbContext applicationDbContextFake)
+        {
+            var fixture = new Fixture();
+
+            fixture.Behaviors.Add(new OmitOnRecursionBehavior());
+
+            var accion = fixture.CreateMany<Acciones>().ToList();
+
+            accion.Add(fixture.Build<Acciones>()
+                .With(tr => tr.Id, "2a82ff8a-1e33-498f-9367-1f8ff9ec6440")
+                .Create()
+                );
+
+            applicationDbContextFake.acciones!.AddRange(accion);
+            applicationDbContextFake.SaveChanges();
+        }
+    }
+}

--- a/UnitTest/Mocks/MockUnitOfWork.cs
+++ b/UnitTest/Mocks/MockUnitOfWork.cs
@@ -1,0 +1,32 @@
+﻿using Infrastructure.Persistence;
+using Infrastructure.Repositories;
+using Microsoft.EntityFrameworkCore;
+using Moq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace UnitTest.Mocks
+{
+    public static class MockUnitOfWork
+    {
+        public static Mock<UnitOfWork> GetUnitOfWork()
+        {
+            Guid dbContextId = Guid.NewGuid();
+
+            var optiones = new DbContextOptionsBuilder<ApplicationDbContext>()
+                .UseInMemoryDatabase(databaseName: $"AutogestionTarsusContext-{dbContextId}")
+                .Options;
+
+            var testDbContextFake = new ApplicationDbContext(optiones);
+
+            testDbContextFake.Database.EnsureDeleted();
+
+            var mockUnitOfWork = new Mock<UnitOfWork>(testDbContextFake);
+
+            return mockUnitOfWork;
+        }
+    }
+}

--- a/UnitTest/UnitTest.csproj
+++ b/UnitTest/UnitTest.csproj
@@ -1,0 +1,35 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="AutoFixture" Version="4.18.1" />
+    <PackageReference Include="AutoMapper" Version="12.0.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.12" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="Shouldly" Version="4.2.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Application\Application.csproj" />
+    <ProjectReference Include="..\Infrastructure\Infrastructure.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="NUnit.Framework" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Las pruebas unitarias fueron creadas basandonos en la logica del patron CQRS que se encuentran en la carpeta Features del proyecto Application. Se hace de esta manera para evaluar especificamente el flujo de reglas de negocio de las entidades del proyecto.

Se crearon 7 pruebas unitarias para evaluar distintos resultados de los flujos de los  7 servicios de Acciones.